### PR TITLE
RevSlice::swap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(any(std, test)), no_std)]
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
 
 //! Offers a reversed view into a slice.
 //!
@@ -23,12 +23,12 @@
 //! assert_eq!(it.next(), Some(2));
 //! ```
 
-#[cfg(any(std, test))]
+#[cfg(any(feature = "std", test))]
 extern crate core;
 
-use core::{iter, slice};
-use core::ops::{Index, IndexMut};
 use core::ops::Range;
+use core::ops::{Index, IndexMut};
+use core::{iter, slice};
 
 /// Adds `.rev()` and `.rev_mut()` methods to slices.
 ///
@@ -79,7 +79,7 @@ impl<T> RevSlice<T> {
     }
 
     fn flip_index(&self, index: usize) -> usize {
-        self.len() - (index+1)
+        self.len() - (index + 1)
     }
 
     fn flip_fencepost(&self, index: usize) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,12 @@ impl<T> RevSlice<T> {
         let (a, b) = self.0.split_at_mut(rmid);
         (b.rev_mut(), a.rev_mut())
     }
+
+    pub fn swap(&mut self, a: usize, b: usize) {
+        let a = self.flip_index(a);
+        let b = self.flip_index(b);
+        self.0.swap(a, b);
+    }
 }
 
 impl<T> Index<usize> for RevSlice<T> {


### PR DESCRIPTION
Analogous to [`slice::swap`](https://doc.rust-lang.org/nightly/std/primitive.slice.html#method.swap), swaps the elements at two indices within a `RevSlice`.

https://discord.com/channels/273534239310479360/273541522815713281/1319479741836951633

(also a drive-by `cargo fmt`, and changing `cfg(std)` to `cfg(feature = "std")`)